### PR TITLE
Fix HTTPS return url generation

### DIFF
--- a/site/helpers/steamid.php
+++ b/site/helpers/steamid.php
@@ -9,24 +9,6 @@
  */
 defined('_JEXEC') or die;
 
-/*
-jimport('joomla.log.log');
-JLog::addLogger(
-    array(
-         // Sets file name
-         'text_file' => 'com_steamid.log.php'
-    ),
-    // Sets messages of all log levels to be sent to the file
-    JLog::ALL,
-    // The log category/categories which should be recorded in this file
-    // In this case, it's just the one category from our extension, still
-    // we need to put it inside an array
-    array('com_steamid')
-);
-// JLog::add(JText::_('STEAMID PHP INIT'), JLog::WARNING, 'com_steamid');
-//JLog::add(JText::_('JTEXT_ERROR_MESSAGE'), JLog::WARNING, 'com_steamid');
-*/
-
 $path = ini_get('include_path');
 $path_extra = JPATH_LIBRARIES.'/openid/';
 $path = $path_extra . PATH_SEPARATOR . $path;
@@ -153,14 +135,6 @@ class SteamidFrontendHelper {
         $form_html = $auth_request->formMarkup(JUri::root(), JRoute::_(self::getCurrentUrl(), true, self::usessl_int() ),
                                                 false, array('id' => $form_id));
         $form_html = str_replace('<input type="submit" value="Continue" />', '',$form_html);
-        // JLog::add(JText::_('Returning form HTML: ' . $form_html ), JLog::DEBUG, 'com_steamid');
-
-        // JLog::add(JText::_('JRoute return with -1: ' . JRoute::_(self::getCurrentUrl(), true, -1) ), JLog::DEBUG, 'com_steamid');// XXX
-        // JLog::add(JText::_('JRoute return with 0: ' . JRoute::_(self::getCurrentUrl(), true, 0) ), JLog::DEBUG, 'com_steamid');// XXX
-        // JLog::add(JText::_('JRoute return without: ' . JRoute::_(self::getCurrentUrl(), true) ), JLog::DEBUG, 'com_steamid');// XXX
-        // JLog::add(JText::_('JRoute return with 1: ' . JRoute::_(self::getCurrentUrl(), true, 1) ), JLog::DEBUG, 'com_steamid');// XXX
-        // JLog::add(JText::_('JRoute return with 2: ' . JRoute::_(self::getCurrentUrl(), true, 2) ), JLog::DEBUG, 'com_steamid');// XXX
-        // JLog::add(JText::_('JRoute return with ssl func: ' . JRoute::_(self::getCurrentUrl(), true, self::usessl_int() ) ), JLog::DEBUG, 'com_steamid');// XXX
 
         return $form_html;
     }

--- a/site/helpers/steamid.php
+++ b/site/helpers/steamid.php
@@ -9,6 +9,24 @@
  */
 defined('_JEXEC') or die;
 
+/*
+jimport('joomla.log.log');
+JLog::addLogger(
+    array(
+         // Sets file name
+         'text_file' => 'com_steamid.log.php'
+    ),
+    // Sets messages of all log levels to be sent to the file
+    JLog::ALL,
+    // The log category/categories which should be recorded in this file
+    // In this case, it's just the one category from our extension, still
+    // we need to put it inside an array
+    array('com_steamid')
+);
+// JLog::add(JText::_('STEAMID PHP INIT'), JLog::WARNING, 'com_steamid');
+//JLog::add(JText::_('JTEXT_ERROR_MESSAGE'), JLog::WARNING, 'com_steamid');
+*/
+
 $path = ini_get('include_path');
 $path_extra = JPATH_LIBRARIES.'/openid/';
 $path = $path_extra . PATH_SEPARATOR . $path;
@@ -101,6 +119,22 @@ class SteamidFrontendHelper {
         return (!$user->get('guest')) ? 'logout' : 'login';
     }
 
+    /**
+     * Return 1 if https url, 2 if http,
+     * -1 if neither.
+     * Used when creating return URL with JRoute().
+     */
+    protected function usessl_int() {
+        $uri = JUri::getInstance();
+        if ($uri->getScheme() == 'https') {
+            return 1;
+        } else if ($uri-getScheme() == 'http') {
+            return 2;
+        } else {
+            return -1;
+        }
+    }
+
     public static function getForm()
     {
         $identifier = 'http://steamcommunity.com/openid';
@@ -116,12 +150,21 @@ class SteamidFrontendHelper {
         }
         // Generate form markup and render it.
         $form_id = 'openid_message';
-        $form_html = $auth_request->formMarkup(JUri::root(), JRoute::_(self::getCurrentUrl(), true, -1),
+        $form_html = $auth_request->formMarkup(JUri::root(), JRoute::_(self::getCurrentUrl(), true, self::usessl_int() ),
                                                 false, array('id' => $form_id));
         $form_html = str_replace('<input type="submit" value="Continue" />', '',$form_html);
+        // JLog::add(JText::_('Returning form HTML: ' . $form_html ), JLog::DEBUG, 'com_steamid');
+
+        // JLog::add(JText::_('JRoute return with -1: ' . JRoute::_(self::getCurrentUrl(), true, -1) ), JLog::DEBUG, 'com_steamid');// XXX
+        // JLog::add(JText::_('JRoute return with 0: ' . JRoute::_(self::getCurrentUrl(), true, 0) ), JLog::DEBUG, 'com_steamid');// XXX
+        // JLog::add(JText::_('JRoute return without: ' . JRoute::_(self::getCurrentUrl(), true) ), JLog::DEBUG, 'com_steamid');// XXX
+        // JLog::add(JText::_('JRoute return with 1: ' . JRoute::_(self::getCurrentUrl(), true, 1) ), JLog::DEBUG, 'com_steamid');// XXX
+        // JLog::add(JText::_('JRoute return with 2: ' . JRoute::_(self::getCurrentUrl(), true, 2) ), JLog::DEBUG, 'com_steamid');// XXX
+        // JLog::add(JText::_('JRoute return with ssl func: ' . JRoute::_(self::getCurrentUrl(), true, self::usessl_int() ) ), JLog::DEBUG, 'com_steamid');// XXX
+
         return $form_html;
     }
-    
+
     public static function getSteamInfo($id)
     {
         $db = JFactory::getDbo();
@@ -130,7 +173,7 @@ class SteamidFrontendHelper {
             ->from('#__steamid')
             ->where('user_id = ' . (int) $id);
         $db->setQuery($query);
-        
+
         return $db->loadObject();
     }
 }

--- a/site/helpers/steamid.php
+++ b/site/helpers/steamid.php
@@ -106,11 +106,11 @@ class SteamidFrontendHelper {
      * -1 if neither.
      * Used when creating return URL with JRoute().
      */
-    protected function usessl_int() {
+    protected function useSslInt() {
         $uri = JUri::getInstance();
         if ($uri->getScheme() == 'https') {
             return 1;
-        } else if ($uri-getScheme() == 'http') {
+        } else if ($uri->getScheme() == 'http') {
             return 2;
         } else {
             return -1;
@@ -132,7 +132,7 @@ class SteamidFrontendHelper {
         }
         // Generate form markup and render it.
         $form_id = 'openid_message';
-        $form_html = $auth_request->formMarkup(JUri::root(), JRoute::_(self::getCurrentUrl(), true, self::usessl_int() ),
+        $form_html = $auth_request->formMarkup(JUri::root(), JRoute::_(self::getCurrentUrl(), true, self::useSslInt() ),
                                                 false, array('id' => $form_id));
         $form_html = str_replace('<input type="submit" value="Continue" />', '',$form_html);
 


### PR DESCRIPTION
When setting the frontend to HTTPS only in a Joomla install, the SteamID login doesn't work because the domain's url schemes didn't match. (https://example.com != http://example.com)

This sets the return url based on the current page's scheme.